### PR TITLE
Fix: Preserve falsy values

### DIFF
--- a/src/sqlalchemy_nest/__init__.py
+++ b/src/sqlalchemy_nest/__init__.py
@@ -17,7 +17,7 @@ def declarative_nested_model_constructor(self: Any, **kwargs: Any) -> None:
     composites = class_mapper(cls_).composites
 
     for key, value in kwargs.items():
-        if not hasattr(cls_, key) or not value:
+        if not hasattr(cls_, key) or value is None:
             continue
 
         if isinstance(value, list):  # "one-to-many"


### PR DESCRIPTION
Fixed a bug where valid falsy values like **0** and **False** were being ignored.